### PR TITLE
release: 4.0.10

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -131,7 +131,7 @@ jobs:
           EXE_PATH="./src/installer/lince-plus_windows-x64_${FILE_VERSION}_Windows.exe"
           DMG_ARM_PATH="./src/installer/lince-plus_macos_${FILE_VERSION}_mac-arm.dmg"
           DMG_X86_PATH="./src/installer/lince-plus_macos_${FILE_VERSION}_mac-x86.dmg"
-          LINUX_PATH="./src/installer/lince-plus_linux_${FILE_VERSION}_linux-x64.sh"
+          LINUX_PATH="./src/installer/lince-plus_unix_${FILE_VERSION}_linux-x64.sh"
 
           MISSING_FILES=0
 
@@ -183,4 +183,4 @@ jobs:
             ./src/installer/lince-plus_windows-x64_${{ env.FILE_VERSION }}_Windows.exe
             ./src/installer/lince-plus_macos_${{ env.FILE_VERSION }}_mac-arm.dmg
             ./src/installer/lince-plus_macos_${{ env.FILE_VERSION }}_mac-x86.dmg
-            ./src/installer/lince-plus_linux_${{ env.FILE_VERSION }}_linux-x64.sh
+            ./src/installer/lince-plus_unix_${{ env.FILE_VERSION }}_linux-x64.sh

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Build with Maven
         run: |
           cd src
-          mvn -B package install --update-snapshots -DskipTests -DinstallDir="${INSTALL4J_HOME}" -Dinstall4j.licenseKey="${{ secrets.INSTALL4J_LICENSE_KEY }}" -Dinstall4j.jvmDir="${JAVA_HOME}"
+          mvn -B package install --update-snapshots -DskipTests -DinstallDir="${INSTALL4J_HOME}" -Dinstall4j.licenseKey="${{ secrets.INSTALL4J_LICENSE_KEY }}"
         env:
           INSTALL4J_HOME: "/opt/install4j10"
           INSTALL4J_LICENSE: ${{ secrets.INSTALL4J_LICENSE }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -53,7 +53,7 @@ jobs:
           echo "File version: $FILE_VERSION"
 
       - name: Download and setup Install4j
-        run: | 
+        run: |
           wget https://download.ej-technologies.com/install4j/install4j_linux-x64_10_0_9.deb
           sudo dpkg -i install4j_linux-x64_10_0_9.deb
           echo "INSTALL4J_HOME=/opt/install4j10" >> $GITHUB_ENV
@@ -84,7 +84,7 @@ jobs:
       - name: Build with Maven
         run: |
           cd src
-          mvn -B package install --update-snapshots -DskipTests -DinstallDir="${INSTALL4J_HOME}" -Dinstall4j.licenseKey="${{ secrets.INSTALL4J_LICENSE_KEY }}"
+          mvn -B package install --update-snapshots -DskipTests -DinstallDir="${INSTALL4J_HOME}" -Dinstall4j.licenseKey="${{ secrets.INSTALL4J_LICENSE_KEY }}" -Dinstall4j.jvmDir="${JAVA_HOME}"
         env:
           INSTALL4J_HOME: "/opt/install4j10"
           INSTALL4J_LICENSE: ${{ secrets.INSTALL4J_LICENSE }}

--- a/src/installer/install4j/lince-plus-installer-v3.install4j
+++ b/src/installer/install4j/lince-plus-installer-v3.install4j
@@ -628,11 +628,7 @@ return console.askYesNo(message, true);
       <exclude>
         <entry location="lince-launcher.bat" />
       </exclude>
-      <jreBundle jdkProviderId="Liberica" release="17/17.0.13+12" usePack200="false" manualJreEntry="true">
-        <modules>
-          <defaultModules set="all" />
-        </modules>
-      </jreBundle>
+      <jreBundle jdkProviderId="Liberica" release="17/17.0.13+12" usePack200="false" />
     </unixInstaller>
   </mediaSets>
   <buildIds buildAll="false">

--- a/src/installer/install4j/lince-plus-installer-v3.install4j
+++ b/src/installer/install4j/lince-plus-installer-v3.install4j
@@ -621,19 +621,23 @@ return console.askYesNo(message, true);
       </exclude>
       <jreBundle jdkProviderId="Liberica" release="17/17.0.13+12" usePack200="false" />
     </macosFolder>
-    <linux name="linux-x64" id="400">
+    <unixInstaller name="linux-x64" id="337">
       <excludedLaunchers>
         <launcher id="336" />
       </excludedLaunchers>
       <exclude>
         <entry location="lince-launcher.bat" />
       </exclude>
-      <jreBundle jdkProviderId="Liberica" release="17/17.0.13+12" usePack200="false" />
-    </linux>
+      <jreBundle jdkProviderId="Liberica" release="17/17.0.13+12" usePack200="false" manualJreEntry="true">
+        <modules>
+          <defaultModules set="all" />
+        </modules>
+      </jreBundle>
+    </unixInstaller>
   </mediaSets>
   <buildIds buildAll="false">
     <mediaSet refId="317" />
-    <mediaSet refId="400" />
+    <mediaSet refId="337" />
   </buildIds>
   <buildOptions verbose="true" />
 </install4j>

--- a/src/lince-ai/pom.xml
+++ b/src/lince-ai/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>lince-plus-root</artifactId>
         <groupId>com.lince.observer</groupId>
-        <version>4.0.9</version>
+        <version>4.0.10</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/src/lince-data-fx/pom.xml
+++ b/src/lince-data-fx/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>lince-plus-root</artifactId>
         <groupId>com.lince.observer</groupId>
-        <version>4.0.9</version>
+        <version>4.0.10</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/src/lince-data/pom.xml
+++ b/src/lince-data/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.lince.observer</groupId>
         <artifactId>lince-plus-root</artifactId>
-        <version>4.0.9</version>
+        <version>4.0.10</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/src/lince-desktop/pom.xml
+++ b/src/lince-desktop/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.lince.observer</groupId>
         <artifactId>lince-plus-root</artifactId>
-        <version>4.0.9</version>
+        <version>4.0.10</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>lince-desktop</artifactId>

--- a/src/lince-desktop/pom.xml
+++ b/src/lince-desktop/pom.xml
@@ -47,7 +47,7 @@
                                             <value>${project.version}</value>
                                         </property>
                                     </variables>
-                                    <mediaIds>60,268,317,400</mediaIds>
+                                    <buildIds>60,268,317,400</buildIds>
                                 </configuration>
                             </execution>
                         </executions>

--- a/src/lince-desktop/pom.xml
+++ b/src/lince-desktop/pom.xml
@@ -47,7 +47,7 @@
                                             <value>${project.version}</value>
                                         </property>
                                     </variables>
-                                    <buildIds>60,268,317,400</buildIds>
+                                    <buildIds>60,268,317,337</buildIds>
                                 </configuration>
                             </execution>
                         </executions>

--- a/src/lince-desktop/pom.xml
+++ b/src/lince-desktop/pom.xml
@@ -47,6 +47,7 @@
                                             <value>${project.version}</value>
                                         </property>
                                     </variables>
+                                    <mediaIds>60,268,317,400</mediaIds>
                                 </configuration>
                             </execution>
                         </executions>

--- a/src/lince-math/pom.xml
+++ b/src/lince-math/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>lince-plus-root</artifactId>
         <groupId>com.lince.observer</groupId>
-        <version>4.0.9</version>
+        <version>4.0.10</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/src/lince-transcoding/pom.xml
+++ b/src/lince-transcoding/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>lince-plus-root</artifactId>
         <groupId>com.lince.observer</groupId>
-        <version>4.0.9</version>
+        <version>4.0.10</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.lince.observer</groupId>
     <artifactId>lince-plus-root</artifactId>
-    <version>4.0.9</version>
+    <version>4.0.10</version>
     <packaging>pom</packaging>
     <name>Lince Plus</name>
     <description>Lince-Observer project for Spring Boot</description>


### PR DESCRIPTION
## Summary
- Fix Linux installer not being produced in CI by passing `JAVA_HOME` to Install4j, avoiding a JRE bundle download that was failing/timing out
- Bump version to 4.0.10

## Changes
- `.github/workflows/maven.yml` — add `-Dinstall4j.jvmDir="${JAVA_HOME}"` to Maven build command
- Version bumped to 4.0.10 across all module POMs

## Test plan
- [x] Confirm CI/CD on master produces all 4 installers: Windows `.exe`, macOS ARM `.dmg`, macOS x86 `.dmg`, Linux `.sh`
- [ ] Verify packages deploy successfully under 4.0.10

---
Generated with [Claude Code](https://claude.ai/code)