### PR TITLE
fix(ci): use SNAPSHOT-aware version for installer check and develop upload

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,15 +42,19 @@ jobs:
           FULL_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout -f src/pom.xml)
           CLEAN_VERSION=$(echo $FULL_VERSION | sed 's/-SNAPSHOT//')
           FILE_VERSION=$(echo $CLEAN_VERSION | sed 's/\./_/g')
+          FULL_FILE_VERSION=$(echo $FULL_VERSION | sed 's/\./_/g')
           echo "FULL_VERSION=$FULL_VERSION" >> $GITHUB_ENV
           echo "CLEAN_VERSION=$CLEAN_VERSION" >> $GITHUB_ENV
           echo "FILE_VERSION=$FILE_VERSION" >> $GITHUB_ENV
+          echo "FULL_FILE_VERSION=$FULL_FILE_VERSION" >> $GITHUB_ENV
           echo "FULL_VERSION=$FULL_VERSION" >> $GITHUB_OUTPUT
           echo "CLEAN_VERSION=$CLEAN_VERSION" >> $GITHUB_OUTPUT
           echo "FILE_VERSION=$FILE_VERSION" >> $GITHUB_OUTPUT
+          echo "FULL_FILE_VERSION=$FULL_FILE_VERSION" >> $GITHUB_OUTPUT
           echo "Full project version: $FULL_VERSION"
           echo "Clean project version: $CLEAN_VERSION"
           echo "File version: $FILE_VERSION"
+          echo "Full file version: $FULL_FILE_VERSION"
 
       - name: Download and setup Install4j
         run: |
@@ -128,10 +132,10 @@ jobs:
       - name: Check for Installer Files
         if: (github.ref == 'refs/heads/master' && !contains(env.FULL_VERSION, 'SNAPSHOT')) || github.ref == 'refs/heads/develop'
         run: |
-          EXE_PATH="./src/installer/lince-plus_windows-x64_${FILE_VERSION}_Windows.exe"
-          DMG_ARM_PATH="./src/installer/lince-plus_macos_${FILE_VERSION}_mac-arm.dmg"
-          DMG_X86_PATH="./src/installer/lince-plus_macos_${FILE_VERSION}_mac-x86.dmg"
-          LINUX_PATH="./src/installer/lince-plus_unix_${FILE_VERSION}_linux-x64.sh"
+          EXE_PATH="./src/installer/lince-plus_windows-x64_${FULL_FILE_VERSION}_Windows.exe"
+          DMG_ARM_PATH="./src/installer/lince-plus_macos_${FULL_FILE_VERSION}_mac-arm.dmg"
+          DMG_X86_PATH="./src/installer/lince-plus_macos_${FULL_FILE_VERSION}_mac-x86.dmg"
+          LINUX_PATH="./src/installer/lince-plus_unix_${FULL_FILE_VERSION}_linux-x64.sh"
 
           MISSING_FILES=0
 
@@ -173,14 +177,14 @@ jobs:
         if: github.ref == 'refs/heads/develop'
         uses: actions/upload-artifact@v4
         with:
-          name: lince-plus-installers-${{ env.FILE_VERSION }}
+          name: lince-plus-installers-${{ env.FULL_FILE_VERSION }}
           if-no-files-found: error
           retention-days: 14
           path: |
-            ./src/installer/lince-plus_windows-x64_${{ env.FILE_VERSION }}_Windows.exe
-            ./src/installer/lince-plus_macos_${{ env.FILE_VERSION }}_mac-arm.dmg
-            ./src/installer/lince-plus_macos_${{ env.FILE_VERSION }}_mac-x86.dmg
-            ./src/installer/lince-plus_unix_${{ env.FILE_VERSION }}_linux-x64.sh
+            ./src/installer/lince-plus_windows-x64_${{ env.FULL_FILE_VERSION }}_Windows.exe
+            ./src/installer/lince-plus_macos_${{ env.FULL_FILE_VERSION }}_mac-arm.dmg
+            ./src/installer/lince-plus_macos_${{ env.FULL_FILE_VERSION }}_mac-x86.dmg
+            ./src/installer/lince-plus_unix_${{ env.FULL_FILE_VERSION }}_linux-x64.sh
 
       - name: Upload Release Assets
         if: github.ref == 'refs/heads/master' && !contains(env.FULL_VERSION, 'SNAPSHOT')


### PR DESCRIPTION
## Summary
The develop CI build (run [25260484269](https://github.com/observesport/lince-plus/actions/runs/25260484269/job/74066827540)) failed at the "Check for Installer Files" step after #129 merged. Install4J produces files named with the full project version (`4_0_12-SNAPSHOT`), but the check was looking for `4_0_12` — the `FILE_VERSION` variable strips `-SNAPSHOT` for the master release-naming convention.

The original master-only flow never hit this because it is gated to non-SNAPSHOT releases (`FULL_VERSION == CLEAN_VERSION` in that path). Enabling the check on develop in #129 surfaced the divergence.

## Changes (`.github/workflows/maven.yml`)
- Compute `FULL_FILE_VERSION = FULL_VERSION` with dots→underscores, preserving the `-SNAPSHOT` suffix.
- "Check for Installer Files" now uses `FULL_FILE_VERSION` (correct on both master non-SNAPSHOT and develop SNAPSHOT — values are identical when there is no SNAPSHOT suffix).
- "Upload Develop Installer Artifacts" uses `FULL_FILE_VERSION` so the upload `path:` entries match the actual produced filenames.
- Master "Upload Release Assets" is unchanged (still uses `FILE_VERSION`; gated to non-SNAPSHOT, so the two variables are equal there).

## Test plan
- [ ] Once merged to develop, the next CI run should pass the file-existence check.
- [ ] The run produces a `lince-plus-installers-4_0_12-SNAPSHOT` artifact containing all four installers.
- [ ] Master release flow unaffected (verified by inspection — no changes to its variables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)