### PR TITLE
chore(ci): bump deprecated Node 20 actions to current majors

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,14 +21,14 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 #      - name: Set up JDK 17
-#        uses: actions/setup-java@v3
+#        uses: actions/setup-java@v4
 #        with:
 #          java-version: '17'
 #          distribution: 'liberica'
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'liberica'
@@ -104,7 +104,7 @@ jobs:
 
       - name: Create Release Draft
         if: github.ref == 'refs/heads/master' && !contains(env.FULL_VERSION, 'SNAPSHOT')
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |


### PR DESCRIPTION
## Summary
The current develop CI run ([25260697560](https://github.com/observesport/lince-plus/actions/runs/25260697560)) emits a Node.js 20 deprecation warning. Bumping the affected actions to current major versions to stay ahead of the June 2nd, 2026 forced switch to Node 24 and the September 16th, 2026 removal of Node 20 from runners.

## Changes (`.github/workflows/maven.yml`)
- `actions/checkout@v3` → `@v4`
- `actions/setup-java@v3` → `@v4` (both active and commented-out references)
- `actions/github-script@v6` → `@v7`

All three are drop-in for our usage (`with: java-version / distribution / cache / server-id` on setup-java, plain `script:` block on github-script, default checkout). No input changes needed.

`actions/upload-artifact@v4` is already current — listed in the warning because v4 still runs on Node 20, but no v5 exists yet.
`softprops/action-gh-release@v1` is third-party and not flagged.

## Test plan
- [ ] CI run on this branch (after merge to develop) is green and the Node 20 deprecation warning is gone.
- [ ] Installer artifacts continue to be produced and uploaded as `lince-plus-installers-4_0_12-SNAPSHOT`.
- [ ] No regression on the master release flow when 4.0.12 is eventually released (smoke check the Release draft creation step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)